### PR TITLE
Get Go unit test to recurse

### DIFF
--- a/build/package/test/go.dockerfile
+++ b/build/package/test/go.dockerfile
@@ -23,5 +23,4 @@ COPY ./go.mod ./go.mod
 COPY ./go.sum ./go.sum
 
 RUN go mod download && \
-    go test -v goweb/internal/usersmgmt/handlers/authuser && \
-    go test -v goweb/cmd/goreact/cli
+    go test -v  ./...


### PR DESCRIPTION
Change so unit tests will be picked up automatically instead of having to explicitly declare.
